### PR TITLE
Updated umbtable.directive.js for a working example

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtable.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbtable.directive.js
@@ -12,7 +12,7 @@
     <div ng-controller="My.TableController as vm">
         
         <umb-table
-            ng-if="items"
+            ng-if="vm.items"
             items="vm.items"
             item-properties="vm.options.includeProperties"
             allow-select-all="vm.allowSelectAll"


### PR DESCRIPTION
I noticed that the example on https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbTable is actually not working. items should be replaced with vm.items.